### PR TITLE
Fix for capture name retrieval

### DIFF
--- a/framework/core/OnigRegexp.m
+++ b/framework/core/OnigRegexp.m
@@ -280,7 +280,7 @@
 int co_name_callback(const OnigUChar* name, const OnigUChar* end, int ngroups, int* group_list, OnigRegex re, void* arg) {
 	OnigResult *result = (OnigResult *)arg;
 	
-	[[result captureNameArray] addObject:[NSString stringWithUTF8String:(const char*)name]];
+	[[result captureNameArray] addObject:[NSString stringWithCharacters:(unichar*)name length:((end-name)/CHAR_SIZE)]];
 	return 0;
 }
 


### PR DESCRIPTION
The capture name stuff I added was broken for names that had more than one character in them, this commit fixes that so the names are properly retrieved.
