### PR TITLE
Added error reporting for OnigRegexp compile 

### DIFF
--- a/framework/core/OnigRegexp.h
+++ b/framework/core/OnigRegexp.h
@@ -34,10 +34,15 @@ typedef enum {
 }
 
 + (OnigRegexp*)compile:(NSString*)expression;
++ (OnigRegexp*)compile:(NSString*)expression error:(NSError **)error;
 + (OnigRegexp*)compileIgnorecase:(NSString*)expression;
++ (OnigRegexp*)compileIgnorecase:(NSString*)expression error:(NSError **)error;
 + (OnigRegexp*)compile:(NSString*)expression ignorecase:(BOOL)ignorecase multiline:(BOOL)multiline;
++ (OnigRegexp*)compile:(NSString*)expression ignorecase:(BOOL)ignorecase multiline:(BOOL)multiline error:(NSError **)error;
 + (OnigRegexp*)compile:(NSString*)expression ignorecase:(BOOL)ignorecase multiline:(BOOL)multiline extended:(BOOL)extended;
++ (OnigRegexp*)compile:(NSString*)expression ignorecase:(BOOL)ignorecase multiline:(BOOL)multiline extended:(BOOL)extended error:(NSError **)error;
 + (OnigRegexp*)compile:(NSString*)expression options:(OnigOption)options;
++ (OnigRegexp*)compile:(NSString*)expression options:(OnigOption)options error:(NSError **)error;
 
 - (OnigResult*)search:(NSString*)target;
 - (OnigResult*)search:(NSString*)target start:(int)start;

--- a/framework/tests/OnigRegexpTest.m
+++ b/framework/tests/OnigRegexpTest.m
@@ -184,4 +184,19 @@
 #endif
 }
 
+- (void)testError
+{
+	NSError *error = NULL;
+	id ret = [OnigRegexp compileIgnorecase:nil error:&error];
+	STAssertNil(ret, @"Parsed expression");
+	STAssertEquals([error code], (NSInteger)ONIG_NORMAL, @"Wrong error code");
+	STAssertEqualObjects([error localizedDescription], @"Invalid expression argument", nil);
+	
+	error = NULL;
+	ret = [OnigRegexp compileIgnorecase:@"(?<openb>\\[)?year(?(<openb>)\\])" error:&error];
+	STAssertNil(ret, @"Parsed expression");
+	STAssertEquals([error code], (NSInteger)ONIGERR_UNDEFINED_GROUP_OPTION, @"Wrong error code");
+	STAssertEqualObjects([error localizedDescription], @"undefined group option", nil);
+}
+
 @end


### PR DESCRIPTION
Added methods to OnigRegexp that take an NSError*\* that gets written to with the error information if the provided expression is invalid or could not be compiled.

Also reindented the tests with tabs instead of spaces since it is my impression you prefer tabs?
