### PR TITLE
Support Xcode6, support multiple syntaxes, and bugfix in Emacs's syntax.

### DIFF
--- a/framework/CocoaOniguruma.xcodeproj/project.pbxproj
+++ b/framework/CocoaOniguruma.xcodeproj/project.pbxproj
@@ -32,7 +32,6 @@
 		7807AC520E2FBB8600A5AB6A /* st.h in Headers */ = {isa = PBXBuildFile; fileRef = 7807AC360E2FBB8600A5AB6A /* st.h */; };
 		78C5E1CD0E39CE5F00F62F5D /* OnigRegexpTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C5E1B70E39CDEE00F62F5D /* OnigRegexpTest.m */; };
 		78C5E21F0E39CF7300F62F5D /* CocoaOniguruma.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* CocoaOniguruma.framework */; };
-		78C5E2310E39CFEA00F62F5D /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C5E2300E39CFEA00F62F5D /* SenTestingKit.framework */; };
 		78C5E26C0E39D0BD00F62F5D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C5E26B0E39D0BD00F62F5D /* Foundation.framework */; };
 		78C5E3B10E39E38C00F62F5D /* CocoaOniguruma.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* CocoaOniguruma.framework */; };
 		78C5E3D00E39E42000F62F5D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 78C5E3C00E39E3D900F62F5D /* main.m */; };
@@ -87,7 +86,6 @@
 		78C5E1B60E39CDEE00F62F5D /* OnigRegexpTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OnigRegexpTest.h; path = tests/OnigRegexpTest.h; sourceTree = "<group>"; };
 		78C5E1B70E39CDEE00F62F5D /* OnigRegexpTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OnigRegexpTest.m; path = tests/OnigRegexpTest.m; sourceTree = "<group>"; };
 		78C5E1E70E39CEBD00F62F5D /* UnitTest-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "UnitTest-Info.plist"; sourceTree = "<group>"; };
-		78C5E2300E39CFEA00F62F5D /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = /Developer/Library/Frameworks/SenTestingKit.framework; sourceTree = "<absolute>"; };
 		78C5E26B0E39D0BD00F62F5D /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		78C5E3A90E39E37F00F62F5D /* TestCommand */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = TestCommand; sourceTree = BUILT_PRODUCTS_DIR; };
 		78C5E3C00E39E3D900F62F5D /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = testcommand/main.m; sourceTree = "<group>"; };
@@ -101,7 +99,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				78C5E21F0E39CF7300F62F5D /* CocoaOniguruma.framework in Frameworks */,
-				78C5E2310E39CFEA00F62F5D /* SenTestingKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -151,7 +148,6 @@
 			isa = PBXGroup;
 			children = (
 				78C5E26B0E39D0BD00F62F5D /* Foundation.framework */,
-				78C5E2300E39CFEA00F62F5D /* SenTestingKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -329,7 +325,7 @@
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastTestingUpgradeCheck = 0510;
+				LastTestingUpgradeCheck = 0620;
 				LastUpgradeCheck = 0510;
 			};
 			buildConfigurationList = 1DEB91B108733DA50010E9CD /* Build configuration list for PBXProject "CocoaOniguruma" */;

--- a/framework/Info.plist
+++ b/framework/Info.plist
@@ -6,21 +6,19 @@
 	<string>English</string>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
-	<key>CFBundleIconFile</key>
-	<string></string>
+	<key>CFBundleGetInfoString</key>
+	<string>Objective-C wrapper for the Oniguruma regular expression library.</string>
 	<key>CFBundleIdentifier</key>
 	<string>net.limechat.CocoaOniguruma</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
+	<string>2</string>
 </dict>
 </plist>

--- a/framework/core/OnigRegexp.h
+++ b/framework/core/OnigRegexp.h
@@ -43,6 +43,7 @@ typedef enum {
 + (OnigRegexp*)compile:(NSString*)expression ignorecase:(BOOL)ignorecase multiline:(BOOL)multiline extended:(BOOL)extended error:(NSError **)error;
 + (OnigRegexp*)compile:(NSString*)expression options:(OnigOption)options;
 + (OnigRegexp*)compile:(NSString*)expression options:(OnigOption)options error:(NSError **)error;
++ (OnigRegexp*)compile:(NSString*)expression options:(OnigOption)theOptions syntax:(OnigSyntaxType *)syntax error:(NSError **)error;
 
 - (OnigResult*)search:(NSString*)target;
 - (OnigResult*)search:(NSString*)target start:(int)start;

--- a/framework/core/OnigRegexp.m
+++ b/framework/core/OnigRegexp.m
@@ -104,6 +104,11 @@ static int captureNameCallback(const OnigUChar* name, const OnigUChar* end, int 
 
 + (OnigRegexp*)compile:(NSString*)expression options:(OnigOption)theOptions error:(NSError **)error
 {
+    return [self compile:expression options:theOptions syntax:ONIG_SYNTAX_DEFAULT error:error];
+}
+
++ (OnigRegexp*)compile:(NSString*)expression options:(OnigOption)theOptions syntax:(OnigSyntaxType *)syntax error:(NSError **)error
+{
     if (!expression) {
         if(error != NULL) {
             //Make NSError;
@@ -127,7 +132,7 @@ static int captureNameCallback(const OnigUChar* name, const OnigUChar* end, int 
                               str + [expression length] * CHAR_SIZE,
                               option,
                               ONIG_ENCODING,
-                              ONIG_SYNTAX_DEFAULT,
+                              syntax,
                               &err);
     }
     

--- a/framework/core/oniguruma/regsyntax.c
+++ b/framework/core/oniguruma/regsyntax.c
@@ -84,24 +84,24 @@ OnigSyntaxType OnigSyntaxPosixExtended = {
 };
 
 OnigSyntaxType OnigSyntaxEmacs = {
-  ( ONIG_SYN_OP_DOT_ANYCHAR | ONIG_SYN_OP_BRACKET_CC |
-    ONIG_SYN_OP_ESC_BRACE_INTERVAL |
-    ONIG_SYN_OP_ESC_LPAREN_SUBEXP | ONIG_SYN_OP_ESC_VBAR_ALT |
-    ONIG_SYN_OP_ASTERISK_ZERO_INF | ONIG_SYN_OP_PLUS_ONE_INF |
-    ONIG_SYN_OP_QMARK_ZERO_ONE | ONIG_SYN_OP_DECIMAL_BACKREF |
-    ONIG_SYN_OP_LINE_ANCHOR | ONIG_SYN_OP_ESC_CONTROL_CHARS )
-  , ONIG_SYN_OP2_ESC_GNU_BUF_ANCHOR
-  , ONIG_SYN_ALLOW_EMPTY_RANGE_IN_CC
-  , ONIG_OPTION_NONE
-  ,
-  {
-      (OnigCodePoint )'\\'                       /* esc */
-    , (OnigCodePoint )ONIG_INEFFECTIVE_META_CHAR /* anychar '.'  */
-    , (OnigCodePoint )ONIG_INEFFECTIVE_META_CHAR /* anytime '*'  */
-    , (OnigCodePoint )ONIG_INEFFECTIVE_META_CHAR /* zero or one time '?' */
-    , (OnigCodePoint )ONIG_INEFFECTIVE_META_CHAR /* one or more time '+' */
-    , (OnigCodePoint )ONIG_INEFFECTIVE_META_CHAR /* anychar anytime */
-  }
+    ( ONIG_SYN_OP_DOT_ANYCHAR | ONIG_SYN_OP_BRACKET_CC |
+     ONIG_SYN_OP_POSIX_BRACKET | ONIG_SYN_OP_ESC_BRACE_INTERVAL |
+     ONIG_SYN_OP_ESC_LPAREN_SUBEXP | ONIG_SYN_OP_ESC_VBAR_ALT |
+     ONIG_SYN_OP_ASTERISK_ZERO_INF | ONIG_SYN_OP_PLUS_ONE_INF |
+     ONIG_SYN_OP_QMARK_ZERO_ONE | ONIG_SYN_OP_DECIMAL_BACKREF |
+     ONIG_SYN_OP_LINE_ANCHOR | ONIG_SYN_OP_ESC_CONTROL_CHARS )
+    , ONIG_SYN_OP2_ESC_GNU_BUF_ANCHOR
+    , ONIG_SYN_ALLOW_EMPTY_RANGE_IN_CC
+    , ONIG_OPTION_NONE
+    ,
+    {
+        (OnigCodePoint )'\\'                       /* esc */
+        , (OnigCodePoint )ONIG_INEFFECTIVE_META_CHAR /* anychar '.'  */
+        , (OnigCodePoint )ONIG_INEFFECTIVE_META_CHAR /* anytime '*'  */
+        , (OnigCodePoint )ONIG_INEFFECTIVE_META_CHAR /* zero or one time '?' */
+        , (OnigCodePoint )ONIG_INEFFECTIVE_META_CHAR /* one or more time '+' */
+        , (OnigCodePoint )ONIG_INEFFECTIVE_META_CHAR /* anychar anytime */
+    }
 };
 
 OnigSyntaxType OnigSyntaxGrep = {

--- a/framework/tests/OnigRegexpTest.m
+++ b/framework/tests/OnigRegexpTest.m
@@ -196,11 +196,16 @@
     OnigResult* r = [e search:@" 012xyz abc789[a-z]+"];
     XCTAssert(NSEqualRanges([r bodyRange], NSMakeRange(14,6)));
     XCTAssertEqualObjects([r body], @"[a-z]+");
-    	
+    
     e = [OnigRegexp compile:@"[a-z]+" options:ONIG_OPTION_DEFAULT syntax:ONIG_SYNTAX_EMACS error:&error];
     r = [e search:@" 012xyz abc789[a-z]+"];
     XCTAssert(NSEqualRanges([r bodyRange], NSMakeRange(4,3)));
     XCTAssertEqualObjects([r body], @"xyz");
+    
+    e = [OnigRegexp compile:@"[[:digit:]]+" options:ONIG_OPTION_DEFAULT syntax:ONIG_SYNTAX_EMACS error:&error];
+    r = [e search:@" 012xyz abc789[a-z]+"];
+    XCTAssert(NSEqualRanges([r bodyRange], NSMakeRange(1,3)));
+    XCTAssertEqualObjects([r body], @"012");
     
     e = [OnigRegexp compile:@"[a-z]+" options:ONIG_OPTION_DEFAULT syntax:ONIG_SYNTAX_JAVA error:&error];
     r = [e search:@" 012xyz abc789[a-z]+"];


### PR DESCRIPTION
Add function `compile:options:syntax:error:` that allows to create regular expression with different syntaxes as supported by Oniguruma. Add corresponding test.

Upgrade tests from `OCUnit` to `XCTest` as required for Xcode 6.

Bugfix in Onigurama's Emacs syntax. Emacs supports classes like `[:digit:]`.